### PR TITLE
Use voxelmanip to optimize mapgen

### DIFF
--- a/mapgen.lua
+++ b/mapgen.lua
@@ -13,7 +13,23 @@
 	darkage:gneiss
 --]]
 
-local function generate_stratus(name, wherein, ceilin, ceil, minp, maxp, seed, stratus_chance, radius, radius_y, deep, height_min, height_max)
+local getID = minetest.get_content_id
+
+local function generate_stratus(data, varea, name, wherein, ceilin, ceil, minp, maxp, seed, stratus_chance, radius, radius_y, deep, height_min, height_max)
+	local c_ore = getID(name)
+	local c_wherein = {}
+	local c_ceilin = {}
+	for k, v in ipairs(wherein) do
+		c_wherein[k] = getID(v)
+	end
+	for k, v in ipairs(ceilin) do
+		c_ceilin[k] = getID(v)
+	end
+	local c_ceil
+	if ceil then
+		c_ceil = getID(ceil)
+	end
+	
 	if maxp.y < height_min or minp.y > height_max then
 		return
 	end
@@ -51,10 +67,10 @@ local function generate_stratus(name, wherein, ceilin, ceil, minp, maxp, seed, s
 				z0 = pr:next(minp.z, z0)
 			end
 			local p0 = {x=x0, y=y0, z=z0}
-			local n = minetest.get_node(p0).name
+			local n = data[varea:indexp(p0)]
 			local i = 0
 			x = 0
-			for k, v in ipairs(ceilin) do
+			for k, v in ipairs(c_ceilin) do
 				if n == v then
 					x = 1
 					break
@@ -63,9 +79,9 @@ local function generate_stratus(name, wherein, ceilin, ceil, minp, maxp, seed, s
 			if x == 1 then
 				for y1=y0-1,y_min,-1 do
 					p0.y=y1
-					n = minetest.get_node(p0).name
+					n = data[varea:indexp(p0)]
 					x = 0
-					for k, v in ipairs(wherein) do
+					for k, v in ipairs(c_wherein) do
 						if n == v then
 							x = 1
 							break
@@ -94,22 +110,22 @@ local function generate_stratus(name, wherein, ceilin, ceil, minp, maxp, seed, s
 							local y2 = y0+y1
 							local z2 = z0+z1
 							local p2 = {x=x2, y=y2, z=z2}
-							n = minetest.get_node(p2).name
+							n = data[varea:indexp(p2)]
 							x = 0
-								for k, v in ipairs(wherein) do
+								for k, v in ipairs(c_wherein) do
 									if n == v then
 										x = 1
 										break
 									end
 							end
 							if x == 1 then
-								if ceil == nil then
-									minetest.set_node(p2, {name=name})
+								if c_ceil == nil then
+									data[varea:indexp(p2)] = c_ore
 									i = i +1
 								else
 									local p3 = {p2.x,p2.y+1,p2}
-									if minetest.get_node(p3).name == ceil then
-										minetest.set_node(p2, {name=name})
+									if data[varea:indexp(p3)] == c_ceil then
+										data[varea:indexp(p2)] = c_ore
 										i = i +1
 									end
 								end
@@ -123,7 +139,14 @@ local function generate_stratus(name, wherein, ceilin, ceil, minp, maxp, seed, s
 	end
 end
 
-local function generate_claylike(name, minp, maxp, seed, chance, minh, maxh, dirt)
+local function generate_claylike(data, varea, name, minp, maxp, seed, chance, minh, maxh, dirt)
+	local c_ore = getID(name)
+	local c_sand = getID("default:sand")
+	local c_dirt = getID("default:dirt")
+	local c_lawn = getID("default:dirt_with_grass")
+	local c_water = getID("default:water_source")
+	local c_air = getID("air")
+
 	if maxp.y >= maxh+1 and minp.y <= minh-1 then
 	local pr = PseudoRandom(seed)
 	local divlen = 4
@@ -135,21 +158,21 @@ local function generate_claylike(name, minp, maxp, seed, chance, minh, maxh, dir
 					for divz=0+1,divs-1-1 do
 						local cx = minp.x + math.floor((divx+0.5)*divlen)
 						local cz = minp.z + math.floor((divz+0.5)*divlen)
-						local up = minetest.get_node({x=cx,y=yy,z=cz}).name
-						local down = minetest.get_node({x=cx,y=yy-1,z=cz}).name
-						if ( up == "default:water_source" or up == "air" ) and ( down == "default:sand" or (dirt == 1 and (down == "default:dirt" or down == "default:dirt_with_grass" ))) then
+						local up = data[varea:index(cx,yy,cz)]
+						local down = data[varea:index(cx,yy-1,cz)]
+						if ( up == c_water or up == c_air ) and ( down == c_sand or (dirt == 1 and (down == c_dirt or down == c_lawn ))) then
 							local is_shallow = true
 							local num_water_around = 0
-							if minetest.get_node({x=cx-divlen*2,y=yy,z=cz}).name == "default:water_source" then
+							if data[varea:index(cx-divlen*2,yy,cz)] == c_water then
 								num_water_around = num_water_around + 1
 							end
-							if minetest.get_node({x=cx+divlen*2,y=yy,z=cz}).name == "default:water_source" then
+							if data[varea:index(cx+divlen*2,yy,cz)] == c_water then
 								num_water_around = num_water_around + 1
 							end
-							if minetest.get_node({x=cx,y=yy,z=cz-divlen*2}).name == "default:water_source" then
+							if data[varea:index(cx,yy,cz-divlen*2)] == c_water then
 								num_water_around = num_water_around + 1
 							end
-							if minetest.get_node({x=cx,y=yy,z=cz+divlen*2}).name == "default:water_source" then
+							if data[varea:index(cx,yy,cz+divlen*2)] == c_water then
 								num_water_around = num_water_around + 1
 							end
 							if num_water_around >= 3 then
@@ -159,9 +182,9 @@ local function generate_claylike(name, minp, maxp, seed, chance, minh, maxh, dir
 								for x1=-divlen,divlen do
 									for z1=-divlen,divlen do
 										local p={x=cx+x1,y=yy-1,z=cz+z1}
-										down = minetest.get_node(p).name
-										if down == "default:sand" or (dirt == 1 and (down == "default:dirt" or down == "default:dirt_with_grass")) then
-											minetest.set_node(p, {name=name})
+										down = data[varea:indexp(p)]
+										if down == c_sand or (dirt == 1 and (down == c_dirt or down == c_lawn)) then
+											data[varea:indexp(p)] = c_ore
 										end
 									end
 								end
@@ -175,7 +198,10 @@ local function generate_claylike(name, minp, maxp, seed, chance, minh, maxh, dir
 end
 
 
-local function generate_ore(name, wherein, minp, maxp, seed, chunks_per_volume, chunk_size, ore_per_chunk, height_min, height_max)
+local function generate_ore(data, varea, name, wherein, minp, maxp, seed, chunks_per_volume, chunk_size, ore_per_chunk, height_min, height_max)
+	local c_ore = getID(name)
+	local c_wherein = getID(wherein)
+
 	if maxp.y < height_min or minp.y > height_max then
 		return
 	end
@@ -199,8 +225,9 @@ local function generate_ore(name, wherein, minp, maxp, seed, chunks_per_volume, 
 							local y2 = y0+y1
 							local z2 = z0+z1
 							local p2 = {x=x2, y=y2, z=z2}
-							if minetest.get_node(p2).name == wherein then
-								minetest.set_node(p2, {name=name})
+							local indexp2 = varea:indexp(p2)
+							if data[indexp2] == c_wherein then
+								data[indexp2] = c_ore
 							end
 						end
 					end
@@ -211,43 +238,50 @@ local function generate_ore(name, wherein, minp, maxp, seed, chunks_per_volume, 
 end
 
 minetest.register_on_generated(function(minp, maxp, seed)
+local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
+local area = VoxelArea:new({MinEdge = emin, MaxEdge = emax})
+local data = vm:get_data()
+
 print("DARKAGE: Generate stratus");
-generate_claylike("darkage:mud", minp, maxp, seed+1, 4, 0, 2, 0)
-generate_claylike("darkage:silt", minp, maxp, seed+2, 4, -1, 1, 1)
-generate_stratus("darkage:chalk",
+generate_claylike(data, area, "darkage:mud", minp, maxp, seed+1, 4, 0, 2, 0)
+generate_claylike(data, area, "darkage:silt", minp, maxp, seed+2, 4, -1, 1, 1)
+generate_stratus(data, area, "darkage:chalk",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+3, 4, 25, 8, 0, -20,  50)
-generate_stratus("darkage:ors",
+generate_stratus(data, area, "darkage:ors",
 				{"default:stone"},
 				{"default:stone","air","default:water_source"}, nil,
 				minp, maxp, seed+4, 4, 25, 7, 50, -200,  500)
-generate_stratus("darkage:shale",
+generate_stratus(data, area, "darkage:shale",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+5, 4, 23, 7, 50, -50,  20)
-generate_stratus("darkage:slate",
+generate_stratus(data, area, "darkage:slate",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+6, 6, 23, 5, 50, -500, 0)
-generate_stratus("darkage:schist",
+generate_stratus(data, area, "darkage:schist",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+7, 6, 19, 6, 50, -31000, -10)
-generate_stratus("darkage:basalt",
+generate_stratus(data, area, "darkage:basalt",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+8, 5, 20, 5, 20, -31000, -50)
-generate_stratus("darkage:marble",
+generate_stratus(data, area, "darkage:marble",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+9, 4, 25, 6, 50, -31000,  -75)
-generate_stratus("darkage:serpentine",
+generate_stratus(data, area, "darkage:serpentine",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+10, 4, 28, 8, 50, -31000,  -350)
-generate_stratus("darkage:gneiss",
+generate_stratus(data, area, "darkage:gneiss",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+11, 4, 15, 5, 50, -31000, -250)
+
+vm:set_data(data)
+vm:write_to_map()
 end)

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -238,6 +238,8 @@ local function generate_ore(data, varea, name, wherein, minp, maxp, seed, chunks
 end
 
 minetest.register_on_generated(function(minp, maxp, seed)
+local t0 = os.clock()
+
 local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
 local area = VoxelArea:new({MinEdge = emin, MaxEdge = emax})
 local data = vm:get_data()
@@ -284,4 +286,6 @@ generate_stratus(data, area, "darkage:gneiss",
 
 vm:set_data(data)
 vm:write_to_map()
+
+print("DARKAGE: time taken : " .. os.clock() - t0)
 end)

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -57,71 +57,70 @@ local function generate_stratus(name, wherein, ceilin, ceil, minp, maxp, seed, s
 			for k, v in ipairs(ceilin) do
 				if n == v then
 					x = 1
-				break
-			end
-		end
-		if x == 1 then
-			for y1=y0-1,y_min,-1 do
-				p0.y=y1
-				n = minetest.get_node(p0).name
-				x = 0
-				for k, v in ipairs(wherein) do
-					if n == v then
-						x = 1
 					break
 				end
 			end
 			if x == 1 then
-				y0=y1-deep
-				if y0 < y_min then
-					y0 = y_min
-				end
-				break
-			end
-		end
-		local rx=pr:next(radius/2,radius)+1
-		local rz=pr:next(radius/2,radius)+1
-		local ry=pr:next(radius_y/2,radius_y)+1
-		for x1=0,rx do
-			rz = rz + 3 - pr:next(1,6)
-			if rz < 1 then
-				rz = 1
-			end
-			for z1=pr:next(1,3),rz do
-				local ry0=ry+ pr:next(1,3)
-				for y1=pr:next(1,3),ry0 do
-					local x2 = x0+x1
-					local y2 = y0+y1
-					local z2 = z0+z1
-					local p2 = {x=x2, y=y2, z=z2}
-					n = minetest.get_node(p2).name
+				for y1=y0-1,y_min,-1 do
+					p0.y=y1
+					n = minetest.get_node(p0).name
 					x = 0
-						for k, v in ipairs(wherein) do
-							if n == v then
-								x = 1
+					for k, v in ipairs(wherein) do
+						if n == v then
+							x = 1
 							break
 						end
+					end
+					if x == 1 then
+						y0=y1-deep
+						if y0 < y_min then
+							y0 = y_min
+						end
+						break
+					end
 				end
-				if x == 1 then
-					if ceil == nil then
-						minetest.set_node(p2, {name=name})
-						i = i +1
-					else
-						local p3 = {p2.x,p2.y+1,p2}
-						if minetest.get_node(p3).name == ceil then
-							minetest.set_node(p2, {name=name})
-							i = i +1
+				local rx=pr:next(radius/2,radius)+1
+				local rz=pr:next(radius/2,radius)+1
+				local ry=pr:next(radius_y/2,radius_y)+1
+				for x1=0,rx do
+					rz = rz + 3 - pr:next(1,6)
+					if rz < 1 then
+						rz = 1
+					end
+					for z1=pr:next(1,3),rz do
+						local ry0=ry+ pr:next(1,3)
+						for y1=pr:next(1,3),ry0 do
+							local x2 = x0+x1
+							local y2 = y0+y1
+							local z2 = z0+z1
+							local p2 = {x=x2, y=y2, z=z2}
+							n = minetest.get_node(p2).name
+							x = 0
+								for k, v in ipairs(wherein) do
+									if n == v then
+										x = 1
+										break
+									end
+							end
+							if x == 1 then
+								if ceil == nil then
+									minetest.set_node(p2, {name=name})
+									i = i +1
+								else
+									local p3 = {p2.x,p2.y+1,p2}
+									if minetest.get_node(p3).name == ceil then
+										minetest.set_node(p2, {name=name})
+										i = i +1
+									end
+								end
+							end
 						end
 					end
 				end
+				print("    generated "..dump(i).." blocks in ("..dump(x0)..","..dump(y0)..","..dump(z0)..")")
 			end
 		end
 	end
-	print("    generated "..dump(i).." blocks in ("..dump(x0)..","..dump(y0)..","..dump(z0)..")")
--- end end end end!
-end
-end
-end
 end
 
 local function generate_claylike(name, minp, maxp, seed, chance, minh, maxh, dirt)

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -237,55 +237,62 @@ local function generate_ore(data, varea, name, wherein, minp, maxp, seed, chunks
 	end
 end
 
-minetest.register_on_generated(function(minp, maxp, seed)
-local t0 = os.clock()
-
-local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
-local area = VoxelArea:new({MinEdge = emin, MaxEdge = emax})
-local data = vm:get_data()
-
-print("DARKAGE: Generate stratus");
-generate_claylike(data, area, "darkage:mud", minp, maxp, seed+1, 4, 0, 2, 0)
-generate_claylike(data, area, "darkage:silt", minp, maxp, seed+2, 4, -1, 1, 1)
-generate_stratus(data, area, "darkage:chalk",
+function darkage_mapgen(data, area, minp, maxp, seed) -- public function, to be used by Lua mapgens
+	local t1 = os.clock()
+	generate_claylike(data, area, "darkage:mud", minp, maxp, seed+1, 4, 0, 2, 0)
+	generate_claylike(data, area, "darkage:silt", minp, maxp, seed+2, 4, -1, 1, 1)
+	generate_stratus(data, area, "darkage:chalk",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+3, 4, 25, 8, 0, -20,  50)
-generate_stratus(data, area, "darkage:ors",
+	generate_stratus(data, area, "darkage:ors",
 				{"default:stone"},
 				{"default:stone","air","default:water_source"}, nil,
 				minp, maxp, seed+4, 4, 25, 7, 50, -200,  500)
-generate_stratus(data, area, "darkage:shale",
+	generate_stratus(data, area, "darkage:shale",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+5, 4, 23, 7, 50, -50,  20)
-generate_stratus(data, area, "darkage:slate",
+	generate_stratus(data, area, "darkage:slate",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+6, 6, 23, 5, 50, -500, 0)
-generate_stratus(data, area, "darkage:schist",
+	generate_stratus(data, area, "darkage:schist",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+7, 6, 19, 6, 50, -31000, -10)
-generate_stratus(data, area, "darkage:basalt",
+	generate_stratus(data, area, "darkage:basalt",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+8, 5, 20, 5, 20, -31000, -50)
-generate_stratus(data, area, "darkage:marble",
+	generate_stratus(data, area, "darkage:marble",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+9, 4, 25, 6, 50, -31000,  -75)
-generate_stratus(data, area, "darkage:serpentine",
+	generate_stratus(data, area, "darkage:serpentine",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+10, 4, 28, 8, 50, -31000,  -350)
-generate_stratus(data, area, "darkage:gneiss",
+	generate_stratus(data, area, "darkage:gneiss",
 				{"default:stone"},
 				{"default:stone","air"}, nil,
 				minp, maxp, seed+11, 4, 15, 5, 50, -31000, -250)
+	print("DARKAGE: calculating time : " .. os.clock() - t1)
+end
 
-vm:set_data(data)
-vm:write_to_map()
+minetest.register_on_mapgen_init(function(mgparams)
+	if mgparams.mgname ~= "singlenode" then
+		minetest.register_on_generated(function(minp, maxp, seed)
+			local t0 = os.clock()
+			local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
+			local area = VoxelArea:new({MinEdge = emin, MaxEdge = emax})
+			local data = vm:get_data()
 
-print("DARKAGE: time taken : " .. os.clock() - t0)
+			darkage_mapgen(data, area, minp, maxp, seed)
+
+			vm:set_data(data)
+			vm:write_to_map()
+			print("DARKAGE: total time taken : " .. os.clock() - t0)
+		end)
+	end
 end)


### PR DESCRIPTION
Hello,

About #2
I've converted the mapgen code to use the `voxelmanip`, more powerful method than `minetest.set_node`, to set thousands of nodes simultaneously.
The time saving is not as big as I expected, maybe 30% less time underground, and the same mapgen time at the surface (50-100 ms on my computer).

The best difference is for Lua mapgens. I've disabled darkage mapgen in singlenode. Lua mapgens should call `darkage_mapgen` directly within the voxelmanip, like this :

    if darkage_mapgen then
        darkage_mapgen(data, area, minp, maxp, seed)
    end
In this case, it takes only 8 ms on my computer, so an optimization of 90%.
Don't hesitate to report me bugs… and spelling mistakes :D